### PR TITLE
change transform functions to maintain their references

### DIFF
--- a/src/components/array-value.js
+++ b/src/components/array-value.js
@@ -1,35 +1,53 @@
-import React from 'react'
-
 import AnyValue from './any-value'
-import defaults from '../utils/defaults'
-import proxy from '../utils/proxy'
-import render from '../utils/render'
 
-const ArrayValue = props => (
-  <AnyValue {...props} {...defaults(props, [])}>
-    {value =>
-      render(props, {
-        ...value,
-        first: value.value[0],
-        last: value.value[Math.max(0, value.value.length - 1)],
-        clear: () => value.set([]),
-        concat: proxy(value, 'concat'),
-        fill: proxy(value, 'fill'),
-        filter: proxy(value, 'filter'),
-        flat: proxy(value, 'flat'),
-        flatMap: proxy(value, 'flatMap'),
-        map: proxy(value, 'map'),
-        reverse: proxy(value, 'reverse'),
-        sort: proxy(value, 'sort'),
-        slice: proxy(value, 'slice'),
-        push: proxy(value, 'push', true),
-        pop: proxy(value, 'pop', true),
-        shift: proxy(value, 'shift', true),
-        unshift: proxy(value, 'unshift', true),
-        splice: proxy(value, 'splice', true),
-      })
-    }
-  </AnyValue>
-)
+class ArrayValue extends AnyValue {
+  constructor(...args) {
+    super(...args, [])
+  }
+
+  get first() {
+    return this.value[0]
+  }
+
+  get last() {
+    return this.value[Math.max(0, this.value.length - 1)]
+  }
+
+  concat = this.proxy('concat')
+  fill = this.proxy('fill')
+  filter = this.proxy('filter')
+  flat = this.proxy('flat')
+  flatMap = this.proxy('flatMap')
+  map = this.proxy('map')
+  reverse = this.proxy('reverse')
+  sort = this.proxy('sort')
+  slice = this.proxy('slice')
+  push = this.proxy('push', true)
+  pop = this.proxy('pop', true)
+  shift = this.proxy('shift', true)
+  unshift = this.proxy('unshift', true)
+  splice = this.proxy('splice', true)
+
+  states = ['value', 'first', 'last']
+  transforms = [
+    'set',
+    'reset',
+    'clear',
+    'concat',
+    'fill',
+    'filter',
+    'flat',
+    'flatMap',
+    'map',
+    'reverse',
+    'sort',
+    'slice',
+    'push',
+    'pop',
+    'shift',
+    'unshift',
+    'splice',
+  ]
+}
 
 export default ArrayValue

--- a/src/components/boolean-value.js
+++ b/src/components/boolean-value.js
@@ -1,19 +1,19 @@
-import React from 'react'
-
 import AnyValue from './any-value'
-import defaults from '../utils/defaults'
-import render from '../utils/render'
 
-const BooleanValue = props => (
-  <AnyValue {...props} {...defaults(props, false)}>
-    {value =>
-      render(props, {
-        ...value,
-        clear: () => value.set(false),
-        toggle: () => value.set(v => !v),
-      })
-    }
-  </AnyValue>
-)
+class BooleanValue extends AnyValue {
+  constructor(props, context) {
+    super(props, context, false)
+  }
+
+  clear = () => {
+    this.set(false)
+  }
+
+  toggle = () => {
+    this.transform(v => !v)
+  }
+
+  transforms = ['set', 'reset', 'clear', 'toggle']
+}
 
 export default BooleanValue

--- a/src/components/date-value.js
+++ b/src/components/date-value.js
@@ -1,88 +1,108 @@
-import React from 'react'
-
 import AnyValue from './any-value'
-import defaults from '../utils/defaults'
-import proxy from '../utils/proxy'
-import render from '../utils/render'
 
-const DateValue = props => (
-  <AnyValue {...props} {...defaults(props, new Date())}>
-    {value => {
-      const d = value.value
-      const date = d.getDate()
-      const hours = d.getHours()
-      const milliseconds = d.getMilliseconds()
-      const minutes = d.getMinutes()
-      const month = d.getMonth()
-      const seconds = d.getSeconds()
-      const year = d.getFullYear()
+class DateValue extends AnyValue {
+  constructor(...args) {
+    super(...args, new Date())
+  }
 
-      const setDate = proxy(value, 'setDate', true)
-      const setHours = proxy(value, 'setHours', true)
-      const setMilliseconds = proxy(value, 'setMilliseconds', true)
-      const setMinutes = proxy(value, 'setMinutes', true)
-      const setMonth = m => value.set(v => setMonthHelper(v, m))
-      const setSeconds = proxy(value, 'setSeconds', true)
-      const setYear = proxy(value, 'setFullYear', true)
+  get date() {
+    return this.value.getDate()
+  }
 
-      const incrementDate = (n = 1) =>
-        value.set(v => {
-          v.setDate(date + n)
-          return v
-        })
-      const incrementHours = (n = 1) => incrementMinutes(n * 60)
-      const incrementMilliseconds = (n = 1) =>
-        value.set(v => new Date(v.getTime() + n))
-      const incrementMinutes = (n = 1) => incrementSeconds(n * 60)
-      const incrementMonth = (n = 1) => value.set(v => addMonthsHelper(v, n))
-      const incrementSeconds = (n = 1) => incrementMilliseconds(n * 1000)
-      const incrementYear = (n = 1) => incrementMonth(n * 12)
+  get hours() {
+    return this.value.getHours()
+  }
 
-      return render(props, {
-        ...value,
-        clear: () => value.set(new Date()),
+  get milliseconds() {
+    return this.value.getMilliseconds()
+  }
 
-        date,
-        hours,
-        milliseconds,
-        minutes,
-        month,
-        seconds,
-        year,
+  get minutes() {
+    return this.value.getMinutes()
+  }
 
-        setDate,
-        setHours,
-        setMilliseconds,
-        setMinutes,
-        setMonth,
-        setSeconds,
-        setYear,
+  get month() {
+    return this.value.getMonth()
+  }
 
-        incrementDate,
-        incrementHours,
-        incrementMilliseconds,
-        incrementMinutes,
-        incrementMonth,
-        incrementSeconds,
-        incrementYear,
+  get seconds() {
+    return this.value.getSeconds()
+  }
 
-        decrementDate: (n = 1) => incrementDate(0 - n),
-        decrementHours: (n = 1) => incrementHours(0 - n),
-        decrementMilliseconds: (n = 1) => incrementMilliseconds(0 - n),
-        decrementMinutes: (n = 1) => incrementMinutes(0 - n),
-        decrementMonth: (n = 1) => incrementMonth(0 - n),
-        decrementSeconds: (n = 1) => incrementSeconds(0 - n),
-        decrementYear: (n = 1) => incrementYear(0 - n),
+  get year() {
+    return this.value.getFullYear()
+  }
 
-        // Provide the years as `*FullYear` as well, since the native JavaScript
-        // APIs are named like that for backwards compatibility.
-        setFullYear: setYear,
-        incrementFullYear: incrementYear,
-        decrementFullYear: (n = 1) => incrementYear(0 - n),
-      })
-    }}
-  </AnyValue>
-)
+  setDate = this.proxy('setDate', true)
+  setHours = this.proxy('setHours', true)
+  setMilliseconds = this.proxy('setMilliseconds', true)
+  setMinutes = this.proxy('setMinutes', true)
+  setMonth = m => this.transform(v => setMonthHelper(v, m))
+  setSeconds = this.proxy('setSeconds', true)
+  setYear = this.proxy('setFullYear', true)
+  setFullYear = (...args) => this.setYear(...args)
+
+  incrementDate = (n = 1) =>
+    this.transform(v => {
+      v.setDate(this.date + n)
+      return v
+    })
+  incrementHours = (n = 1) => this.incrementMinutes(n * 60)
+  incrementMilliseconds = (n = 1) =>
+    this.transform(v => new Date(v.getTime() + n))
+  incrementMinutes = (n = 1) => this.incrementSeconds(n * 60)
+  incrementMonth = (n = 1) => this.transform(v => incrementMonthHelper(v, n))
+  incrementSeconds = (n = 1) => this.incrementMilliseconds(n * 1000)
+  incrementYear = (n = 1) => this.incrementMonth(n * 12)
+  incrementFullYear = (...args) => this.incrementYear(...args)
+
+  decrementDate = (n = 1) => this.incrementDate(0 - n)
+  decrementHours = (n = 1) => this.incrementHours(0 - n)
+  decrementMilliseconds = (n = 1) => this.incrementMilliseconds(0 - n)
+  decrementMinutes = (n = 1) => this.incrementMinutes(0 - n)
+  decrementMonth = (n = 1) => this.incrementMonth(0 - n)
+  decrementSeconds = (n = 1) => this.incrementSeconds(0 - n)
+  decrementYear = (n = 1) => this.incrementYear(0 - n)
+  decrementFullYear = (...args) => this.decrementYear(...args)
+
+  states = [
+    'value',
+    'date',
+    'hours',
+    'milliseconds',
+    'minutes',
+    'month',
+    'seconds',
+    'year',
+  ]
+
+  transforms = [
+    'set',
+    'reset',
+    'clear',
+    'decrementDate',
+    'decrementHours',
+    'decrementMilliseconds',
+    'decrementMinutes',
+    'decrementMonth',
+    'decrementSeconds',
+    'decrementYear',
+    'incrementDate',
+    'incrementHours',
+    'incrementMilliseconds',
+    'incrementMinutes',
+    'incrementMonth',
+    'incrementSeconds',
+    'incrementYear',
+    'setDate',
+    'setHours',
+    'setMilliseconds',
+    'setMinutes',
+    'setMonth',
+    'setSeconds',
+    'setYear',
+  ]
+}
 
 function setMonthHelper(date, month) {
   const year = date.getFullYear()
@@ -95,7 +115,7 @@ function setMonthHelper(date, month) {
   return date
 }
 
-function addMonthsHelper(date, amount) {
+function incrementMonthHelper(date, amount) {
   const year = date.getFullYear()
   const desiredMonth = date.getMonth() + amount
   const desired = new Date(0)

--- a/src/components/map-value.js
+++ b/src/components/map-value.js
@@ -1,26 +1,22 @@
-import React from 'react'
-
 import AnyValue from './any-value'
-import defaults from '../utils/defaults'
-import proxy from '../utils/proxy'
-import render from '../utils/render'
 
-const MapValue = props => (
-  <AnyValue {...props} {...defaults(props, new Map())}>
-    {value =>
-      render(props, {
-        ...value,
-        set: (...args) => {
-          return args.length === 1
-            ? value.set(...args)
-            : value.set(v => v.set(...args))
-        },
-        unset: proxy(value, 'delete', true),
-        delete: proxy(value, 'delete', true),
-        clear: proxy(value, 'clear', true),
-      })
-    }
-  </AnyValue>
-)
+class MapValue extends AnyValue {
+  constructor(...args) {
+    super(...args, new Map())
+  }
+
+  set = (...args) => {
+    const first = args[0]
+    return args.length === 1
+      ? this.transform(v => (typeof first === 'function' ? first(v) : first))
+      : this.transform(v => v.set(...args))
+  }
+
+  unset = this.proxy('delete', true)
+  delete = this.proxy('delete', true)
+  clear = this.proxy('clear', true)
+
+  transforms = ['set', 'reset', 'clear', 'unset', 'delete', 'clear']
+}
 
 export default MapValue

--- a/src/components/number-value.js
+++ b/src/components/number-value.js
@@ -1,20 +1,19 @@
-import React from 'react'
-
 import AnyValue from './any-value'
-import defaults from '../utils/defaults'
-import render from '../utils/render'
 
-const NumberValue = props => (
-  <AnyValue {...props} {...defaults(props, 0)}>
-    {value =>
-      render(props, {
-        ...value,
-        clear: () => value.set(0),
-        increment: (n = 1) => value.set(v => v + n),
-        decrement: (n = 1) => value.set(v => v - n),
-      })
-    }
-  </AnyValue>
-)
+class NumberValue extends AnyValue {
+  constructor(...args) {
+    super(...args, 0)
+  }
+
+  increment = (n = 1) => {
+    this.transform(v => v + n)
+  }
+
+  decrement = (n = 1) => {
+    this.transform(v => v - n)
+  }
+
+  transforms = ['set', 'reset', 'clear', 'increment', 'decrement']
+}
 
 export default NumberValue

--- a/src/components/set-value.js
+++ b/src/components/set-value.js
@@ -1,26 +1,21 @@
-import React from 'react'
-
 import AnyValue from './any-value'
-import defaults from '../utils/defaults'
-import proxy from '../utils/proxy'
-import render from '../utils/render'
 
-const SetValue = props => (
-  <AnyValue {...props} {...defaults(props, new Set())}>
-    {value => {
-      const add = proxy(value, 'add')
-      const remove = proxy(value, 'delete', true)
-      const clear = proxy(value, 'clear', true)
-      return render(props, {
-        ...value,
-        add,
-        remove,
-        delete: remove,
-        clear,
-        toggle: (val, boolean) => (boolean ? add(val) : remove(val)),
-      })
-    }}
-  </AnyValue>
-)
+class SetValue extends AnyValue {
+  constructor(...args) {
+    super(...args, new Set())
+  }
+
+  add = this.proxy('add')
+  remove = this.proxy('delete', true)
+  delete = this.proxy('delete', true)
+  clear = this.proxy('clear', true)
+
+  toggle = (val, boolean) => {
+    const method = boolean ? 'add' : 'remove'
+    this[method](val)
+  }
+
+  transforms = ['set', 'reset', 'clear', 'add', 'remove', 'delete', 'toggle']
+}
 
 export default SetValue

--- a/src/components/string-value.js
+++ b/src/components/string-value.js
@@ -1,33 +1,44 @@
-import React from 'react'
-
 import AnyValue from './any-value'
-import defaults from '../utils/defaults'
-import proxy from '../utils/proxy'
-import render from '../utils/render'
 
-const ArrayValue = props => (
-  <AnyValue {...props} {...defaults(props, [])}>
-    {value =>
-      render(props, {
-        ...value,
-        clear: () => value.set(''),
-        concat: proxy(value, 'concat'),
-        normalize: proxy(value, 'normalize'),
-        padEnd: proxy(value, 'padEnd'),
-        padStart: proxy(value, 'padStart'),
-        repeat: proxy(value, 'repeat'),
-        replace: proxy(value, 'replace'),
-        slice: proxy(value, 'slice'),
-        substr: proxy(value, 'substr'),
-        substring: proxy(value, 'substring'),
-        toLowerCase: proxy(value, 'toLowerCase'),
-        toUpperCase: proxy(value, 'toUpperCase'),
-        trim: proxy(value, 'trim'),
-        trimEnd: proxy(value, 'trimEnd'),
-        trimStart: proxy(value, 'trimStart'),
-      })
-    }
-  </AnyValue>
-)
+class StringValue extends AnyValue {
+  constructor(...args) {
+    super(...args, '')
+  }
 
-export default ArrayValue
+  concat = this.proxy('concat')
+  normalize = this.proxy('normalize')
+  padEnd = this.proxy('padEnd')
+  padStart = this.proxy('padStart')
+  repeat = this.proxy('repeat')
+  replace = this.proxy('replace')
+  slice = this.proxy('slice')
+  substr = this.proxy('substr')
+  substring = this.proxy('substring')
+  toLowerCase = this.proxy('toLowerCase')
+  toUpperCase = this.proxy('toUpperCase')
+  trim = this.proxy('trim')
+  trimEnd = this.proxy('trimEnd')
+  trimStart = this.proxy('trimStart')
+
+  transforms = [
+    'set',
+    'reset',
+    'clear',
+    'concat',
+    'normalize',
+    'padEnd',
+    'padStart',
+    'repeat',
+    'replace',
+    'slice',
+    'substr',
+    'substring',
+    'toLowerCase',
+    'toUpperCase',
+    'trim',
+    'trimEnd',
+    'trimStart',
+  ]
+}
+
+export default StringValue


### PR DESCRIPTION
This is a first pass at fixing #6. Instead of composing `<AnyValue>`, the other components inherit from it instead. This enables them to store bound versions of their transforms on their instance, which means that the transform functions are needlessly recreated with each render.

Also happily looks like it slightly reduces the bundle size. Although this is just a first pass, I think it can be cleaned up and reduced even further with this method next.