### PR TITLE
Fix clone values

### DIFF
--- a/src/components/any-value.js
+++ b/src/components/any-value.js
@@ -54,19 +54,11 @@ class AnyValue extends React.Component {
   }
 
   reset = () => {
-    this.transform(() => {
-      const { initial } = this.state
-      const next = this.clone ? this.clone(initial) : initial
-      return next
-    })
+    this.transform(() => this.clone(this.state.initial))
   }
 
   clear = () => {
-    this.transform(() => {
-      const { empty } = this.state
-      const next = this.clone ? this.clone(empty) : empty
-      return next
-    })
+    this.transform(() => this.clone(this.state.empty))
   }
 
   states = ['value']

--- a/src/components/any-value.js
+++ b/src/components/any-value.js
@@ -17,10 +17,11 @@ class AnyValue extends React.Component {
     return state.controlled ? props.value : state.value
   }
 
-  transform = fn => {
+  transform(fn) {
     this.setState(
       existing => {
-        const next = fn(existing.value)
+        let next = fn(existing.value)
+        if (next === existing.value) next = this.clone(next)
         return { value: next }
       },
       () => {
@@ -39,16 +40,20 @@ class AnyValue extends React.Component {
     }
   }
 
+  clone(value) {
+    return value
+  }
+
   set = next => {
     this.transform(v => (typeof next === 'function' ? next(v) : next))
   }
 
   reset = () => {
-    this.transform(() => this.state.initial)
+    this.transform(() => this.clone(this.state.initial))
   }
 
   clear = () => {
-    this.transform(() => this.state.empty)
+    this.transform(() => this.clone(this.state.empty))
   }
 
   states = ['value']

--- a/src/components/any-value.js
+++ b/src/components/any-value.js
@@ -17,11 +17,17 @@ class AnyValue extends React.Component {
     return state.controlled ? props.value : state.value
   }
 
-  transform(fn) {
+  clone(value) {
+    return value
+  }
+
+  transform(fn, options = {}) {
+    const { mutate = false } = options
+
     this.setState(
       existing => {
-        let next = fn(existing.value)
-        if (next === existing.value) next = this.clone(next)
+        const current = mutate ? this.clone(existing.value) : existing.value
+        const next = fn(current)
         return { value: next }
       },
       () => {
@@ -31,17 +37,16 @@ class AnyValue extends React.Component {
     )
   }
 
-  proxy(method, mutates) {
+  proxy(method, mutate) {
     return (...args) => {
-      this.transform(v => {
-        const ret = v[method](...args)
-        return mutates ? v : ret
-      })
+      this.transform(
+        v => {
+          const ret = v[method](...args)
+          return mutate ? v : ret
+        },
+        { mutate }
+      )
     }
-  }
-
-  clone(value) {
-    return value
   }
 
   set = next => {
@@ -49,11 +54,19 @@ class AnyValue extends React.Component {
   }
 
   reset = () => {
-    this.transform(() => this.clone(this.state.initial))
+    this.transform(() => {
+      const { initial } = this.state
+      const next = this.clone ? this.clone(initial) : initial
+      return next
+    })
   }
 
   clear = () => {
-    this.transform(() => this.clone(this.state.empty))
+    this.transform(() => {
+      const { empty } = this.state
+      const next = this.clone ? this.clone(empty) : empty
+      return next
+    })
   }
 
   states = ['value']

--- a/src/components/array-value.js
+++ b/src/components/array-value.js
@@ -5,6 +5,10 @@ class ArrayValue extends AnyValue {
     super(...args, [])
   }
 
+  clone(value) {
+    return value.slice()
+  }
+
   get first() {
     return this.value[0]
   }
@@ -14,13 +18,13 @@ class ArrayValue extends AnyValue {
   }
 
   concat = this.proxy('concat')
-  fill = this.proxy('fill')
+  fill = this.proxy('fill', true)
   filter = this.proxy('filter')
   flat = this.proxy('flat')
   flatMap = this.proxy('flatMap')
   map = this.proxy('map')
-  reverse = this.proxy('reverse')
-  sort = this.proxy('sort')
+  reverse = this.proxy('reverse', true)
+  sort = this.proxy('sort', true)
   slice = this.proxy('slice')
   push = this.proxy('push', true)
   pop = this.proxy('pop', true)

--- a/src/components/date-value.js
+++ b/src/components/date-value.js
@@ -5,6 +5,10 @@ class DateValue extends AnyValue {
     super(...args, new Date())
   }
 
+  clone(value) {
+    return new Date(value.getTime())
+  }
+
   get date() {
     return this.value.getDate()
   }

--- a/src/components/map-value.js
+++ b/src/components/map-value.js
@@ -5,6 +5,10 @@ class MapValue extends AnyValue {
     super(...args, new Map())
   }
 
+  clone(value) {
+    return new Map(value)
+  }
+
   set = (...args) => {
     const first = args[0]
     return args.length === 1

--- a/src/components/set-value.js
+++ b/src/components/set-value.js
@@ -5,6 +5,10 @@ class SetValue extends AnyValue {
     super(...args, new Set())
   }
 
+  clone(value) {
+    return new Set(value)
+  }
+
   add = this.proxy('add')
   remove = this.proxy('delete', true)
   delete = this.proxy('delete', true)

--- a/test/components/array-value.js
+++ b/test/components/array-value.js
@@ -11,17 +11,6 @@ describe('<ArrayValue>', () => {
     assert.deepEqual(fake.lastArg.value, [])
   })
 
-  it('transform(fn) clones', () => {
-    const fake = sinon.fake.returns(null)
-    const renderer = Renderer.create(<ArrayValue children={fake} />)
-    const value = []
-    const instance = renderer.getInstance()
-    instance.transform(() => value)
-    instance.transform(() => value)
-    assert.deepEqual(instance.value, value)
-    assert.notEqual(instance.value, value)
-  })
-
   it('value', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<ArrayValue children={fake} value={['a']} />)
@@ -90,11 +79,14 @@ describe('<ArrayValue>', () => {
     assert.deepEqual(fake.lastArg.value, [0, 1, 2, 3, 4, 5])
   })
 
-  it('fill()', () => {
+  it('fill() (mutates)', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<ArrayValue children={fake} defaultValue={[0, 1, 2]} />)
+    const previous = fake.lastArg.value
     fake.lastArg.fill(true)
-    assert.deepEqual(fake.lastArg.value, [true, true, true])
+    const { value } = fake.lastArg
+    assert.deepEqual(value, [true, true, true])
+    assert.notEqual(value, previous)
   })
 
   it('filter(fn)', () => {
@@ -137,22 +129,28 @@ describe('<ArrayValue>', () => {
     assert.deepEqual(fake.lastArg.value, ['aaa', 'bbb'])
   })
 
-  it('reverse()', () => {
+  it('reverse() (mutates)', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<ArrayValue children={fake} defaultValue={['a', 'b']} />)
+    const previous = fake.lastArg.value
     fake.lastArg.reverse()
-    assert.deepEqual(fake.lastArg.value, ['b', 'a'])
+    const { value } = fake.lastArg
+    assert.deepEqual(value, ['b', 'a'])
+    assert.notEqual(value, previous)
   })
 
-  it('sort()', () => {
+  it('sort() (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
       <ArrayValue children={fake} defaultValue={['b', 'c', 'a']} />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.sort()
-    assert.deepEqual(fake.lastArg.value, ['a', 'b', 'c'])
+    const { value } = fake.lastArg
+    assert.deepEqual(value, ['a', 'b', 'c'])
+    assert.notEqual(value, previous)
   })
 
   it('slice()', () => {
@@ -166,59 +164,74 @@ describe('<ArrayValue>', () => {
     assert.deepEqual(fake.lastArg.value, ['b', 'c'])
   })
 
-  it('push(val)', () => {
+  it('push(val) (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
       <ArrayValue children={fake} defaultValue={['a', 'b', 'c']} />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.push('d')
-    assert.deepEqual(fake.lastArg.value, ['a', 'b', 'c', 'd'])
+    const { value } = fake.lastArg
+    assert.deepEqual(value, ['a', 'b', 'c', 'd'])
+    assert.notEqual(value, previous)
   })
 
-  it('pop()', () => {
+  it('pop() (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
       <ArrayValue children={fake} defaultValue={['a', 'b', 'c']} />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.pop()
-    assert.deepEqual(fake.lastArg.value, ['a', 'b'])
+    const { value } = fake.lastArg
+    assert.deepEqual(value, ['a', 'b'])
+    assert.notEqual(value, previous)
   })
 
-  it('shift()', () => {
+  it('shift() (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
       <ArrayValue children={fake} defaultValue={['a', 'b', 'c']} />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.shift()
-    assert.deepEqual(fake.lastArg.value, ['b', 'c'])
+    const { value } = fake.lastArg
+    assert.deepEqual(value, ['b', 'c'])
+    assert.notEqual(value, previous)
   })
 
-  it('unshift(val)', () => {
+  it('unshift(val) (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
       <ArrayValue children={fake} defaultValue={['a', 'b', 'c']} />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.unshift('d')
-    assert.deepEqual(fake.lastArg.value, ['d', 'a', 'b', 'c'])
+    const { value } = fake.lastArg
+    assert.deepEqual(value, ['d', 'a', 'b', 'c'])
+    assert.notEqual(value, previous)
   })
 
-  it('splice()', () => {
+  it('splice() (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
       <ArrayValue children={fake} defaultValue={['a', 'b', 'c']} />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.splice(1, 1, 'd')
-    assert.deepEqual(fake.lastArg.value, ['a', 'd', 'c'])
+    const { value } = fake.lastArg
+    assert.deepEqual(value, ['a', 'd', 'c'])
+    assert.notEqual(value, previous)
   })
 
   it('onChange', () => {

--- a/test/components/array-value.js
+++ b/test/components/array-value.js
@@ -11,6 +11,17 @@ describe('<ArrayValue>', () => {
     assert.deepEqual(fake.lastArg.value, [])
   })
 
+  it('transform(fn) clones', () => {
+    const fake = sinon.fake.returns(null)
+    const renderer = Renderer.create(<ArrayValue children={fake} />)
+    const value = []
+    const instance = renderer.getInstance()
+    instance.transform(() => value)
+    instance.transform(() => value)
+    assert.deepEqual(instance.value, value)
+    assert.notEqual(instance.value, value)
+  })
+
   it('value', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<ArrayValue children={fake} value={['a']} />)

--- a/test/components/date-value.js
+++ b/test/components/date-value.js
@@ -13,6 +13,17 @@ describe('<DateValue>', () => {
     assert.deepEqual(actual, expected)
   })
 
+  it('transform(fn) clones', () => {
+    const fake = sinon.fake.returns(null)
+    const renderer = Renderer.create(<DateValue children={fake} />)
+    const value = new Date()
+    const instance = renderer.getInstance()
+    instance.transform(() => value)
+    instance.transform(() => value)
+    assert.deepEqual(instance.value, value)
+    assert.notEqual(instance.value, value)
+  })
+
   it('value', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<DateValue children={fake} value={new Date(0)} />)

--- a/test/components/date-value.js
+++ b/test/components/date-value.js
@@ -13,17 +13,6 @@ describe('<DateValue>', () => {
     assert.deepEqual(actual, expected)
   })
 
-  it('transform(fn) clones', () => {
-    const fake = sinon.fake.returns(null)
-    const renderer = Renderer.create(<DateValue children={fake} />)
-    const value = new Date()
-    const instance = renderer.getInstance()
-    instance.transform(() => value)
-    instance.transform(() => value)
-    assert.deepEqual(instance.value, value)
-    assert.notEqual(instance.value, value)
-  })
-
   it('value', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<DateValue children={fake} value={new Date(0)} />)
@@ -154,7 +143,7 @@ describe('<DateValue>', () => {
     assert.deepEqual(fake.lastArg.milliseconds, 293)
   })
 
-  it('setYear(n)', () => {
+  it('setYear(n) (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
@@ -164,8 +153,11 @@ describe('<DateValue>', () => {
       />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.setYear(1999)
-    assert.deepEqual(fake.lastArg.value, new Date('1999-12-20T13:42:21'))
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Date('1999-12-20T13:42:21'))
+    assert.notEqual(value, previous)
   })
 
   it('setMonth(n)', () => {
@@ -196,7 +188,7 @@ describe('<DateValue>', () => {
     assert.deepEqual(fake.lastArg.value, new Date('2000-02-29T13:42:21'))
   })
 
-  it('setDate(n)', () => {
+  it('setDate(n) (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
@@ -206,11 +198,14 @@ describe('<DateValue>', () => {
       />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.setDate(10)
-    assert.deepEqual(fake.lastArg.value, new Date('2000-12-10T13:42:21'))
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Date('2000-12-10T13:42:21'))
+    assert.notEqual(value, previous)
   })
 
-  it('setHours(n)', () => {
+  it('setHours(n) (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
@@ -220,11 +215,14 @@ describe('<DateValue>', () => {
       />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.setHours(10)
-    assert.deepEqual(fake.lastArg.value, new Date('2000-12-20T10:42:21'))
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Date('2000-12-20T10:42:21'))
+    assert.notEqual(value, previous)
   })
 
-  it('setMinutes(n)', () => {
+  it('setMinutes(n) (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
@@ -234,11 +232,14 @@ describe('<DateValue>', () => {
       />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.setMinutes(10)
-    assert.deepEqual(fake.lastArg.value, new Date('2000-12-20T13:10:21'))
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Date('2000-12-20T13:10:21'))
+    assert.notEqual(value, previous)
   })
 
-  it('setSeconds(n)', () => {
+  it('setSeconds(n) (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
@@ -248,11 +249,14 @@ describe('<DateValue>', () => {
       />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.setSeconds(10)
-    assert.deepEqual(fake.lastArg.value, new Date('2000-12-20T13:42:10'))
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Date('2000-12-20T13:42:10'))
+    assert.notEqual(value, previous)
   })
 
-  it('setMilliseconds(n)', () => {
+  it('setMilliseconds(n) (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
@@ -262,8 +266,11 @@ describe('<DateValue>', () => {
       />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.setMilliseconds(10)
-    assert.deepEqual(fake.lastArg.value, new Date('2000-12-20T13:42:21.010'))
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Date('2000-12-20T13:42:21.010'))
+    assert.notEqual(value, previous)
   })
 
   it('incrementYear()', () => {

--- a/test/components/map-value.js
+++ b/test/components/map-value.js
@@ -11,6 +11,17 @@ describe('<MapValue>', () => {
     assert.deepEqual(fake.lastArg.value, new Map())
   })
 
+  it('transform(fn) clones', () => {
+    const fake = sinon.fake.returns(null)
+    const renderer = Renderer.create(<MapValue children={fake} />)
+    const value = new Map()
+    const instance = renderer.getInstance()
+    instance.transform(() => value)
+    instance.transform(() => value)
+    assert.deepEqual(instance.value, value)
+    assert.notEqual(instance.value, value)
+  })
+
   it('value', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<MapValue children={fake} value={new Map([['a', 1]])} />)
@@ -38,10 +49,9 @@ describe('<MapValue>', () => {
 
   it('reset()', () => {
     const fake = sinon.fake.returns(null)
+    const initial = new Map([['a', 1]])
 
-    Renderer.create(
-      <MapValue children={fake} defaultValue={new Map([['a', 1]])} />
-    )
+    Renderer.create(<MapValue children={fake} defaultValue={initial} />)
 
     fake.lastArg.set(new Map([['b', 2]]))
     fake.lastArg.reset()

--- a/test/components/map-value.js
+++ b/test/components/map-value.js
@@ -11,17 +11,6 @@ describe('<MapValue>', () => {
     assert.deepEqual(fake.lastArg.value, new Map())
   })
 
-  it('transform(fn) clones', () => {
-    const fake = sinon.fake.returns(null)
-    const renderer = Renderer.create(<MapValue children={fake} />)
-    const value = new Map()
-    const instance = renderer.getInstance()
-    instance.transform(() => value)
-    instance.transform(() => value)
-    assert.deepEqual(instance.value, value)
-    assert.notEqual(instance.value, value)
-  })
-
   it('value', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<MapValue children={fake} value={new Map([['a', 1]])} />)
@@ -47,18 +36,18 @@ describe('<MapValue>', () => {
     assert.deepEqual(fake.lastArg.value, new Map([['b', 2]]))
   })
 
-  it('reset()', () => {
+  it('reset() (mutates)', () => {
     const fake = sinon.fake.returns(null)
     const initial = new Map([['a', 1]])
-
     Renderer.create(<MapValue children={fake} defaultValue={initial} />)
-
     fake.lastArg.set(new Map([['b', 2]]))
     fake.lastArg.reset()
-    assert.deepEqual(fake.lastArg.value, new Map([['a', 1]]))
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Map([['a', 1]]))
+    assert.notEqual(value, initial)
   })
 
-  it('clear()', () => {
+  it('clear() (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
@@ -66,8 +55,11 @@ describe('<MapValue>', () => {
     )
 
     fake.lastArg.set(new Map([['b', 2]]))
+    const previous = fake.lastArg.value
     fake.lastArg.clear()
-    assert.deepEqual(fake.lastArg.value, new Map())
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Map())
+    assert.notEqual(value, previous)
   })
 
   it('set(key, val)', () => {
@@ -77,26 +69,32 @@ describe('<MapValue>', () => {
     assert.deepEqual(fake.lastArg.value, new Map([['b', 2]]))
   })
 
-  it('delete(key)', () => {
+  it('delete(key) (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
       <MapValue children={fake} defaultValue={new Map([['a', 1], ['b', 2]])} />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.delete('a')
-    assert.deepEqual(fake.lastArg.value, new Map([['b', 2]]))
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Map([['b', 2]]))
+    assert.notEqual(value, previous)
   })
 
-  it('unset(key) (alias)', () => {
+  it('unset(key) (alias) (mutates)', () => {
     const fake = sinon.fake.returns(null)
 
     Renderer.create(
       <MapValue children={fake} defaultValue={new Map([['a', 1], ['b', 2]])} />
     )
 
+    const previous = fake.lastArg.value
     fake.lastArg.unset('a')
-    assert.deepEqual(fake.lastArg.value, new Map([['b', 2]]))
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Map([['b', 2]]))
+    assert.notEqual(value, previous)
   })
 
   it('onChange', () => {

--- a/test/components/set-value.js
+++ b/test/components/set-value.js
@@ -11,6 +11,17 @@ describe('<SetValue>', () => {
     assert.deepEqual(fake.lastArg.value, new Set())
   })
 
+  it('transform(fn) clones', () => {
+    const fake = sinon.fake.returns(null)
+    const renderer = Renderer.create(<SetValue children={fake} />)
+    const value = new Set()
+    const instance = renderer.getInstance()
+    instance.transform(() => value)
+    instance.transform(() => value)
+    assert.deepEqual(instance.value, value)
+    assert.notEqual(instance.value, value)
+  })
+
   it('value', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<SetValue children={fake} value={new Set([1])} />)

--- a/test/components/set-value.js
+++ b/test/components/set-value.js
@@ -11,17 +11,6 @@ describe('<SetValue>', () => {
     assert.deepEqual(fake.lastArg.value, new Set())
   })
 
-  it('transform(fn) clones', () => {
-    const fake = sinon.fake.returns(null)
-    const renderer = Renderer.create(<SetValue children={fake} />)
-    const value = new Set()
-    const instance = renderer.getInstance()
-    instance.transform(() => value)
-    instance.transform(() => value)
-    assert.deepEqual(instance.value, value)
-    assert.notEqual(instance.value, value)
-  })
-
   it('value', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<SetValue children={fake} value={new Set([1])} />)
@@ -43,20 +32,26 @@ describe('<SetValue>', () => {
     assert.deepEqual(fake.lastArg.value, new Set([2]))
   })
 
-  it('reset()', () => {
+  it('reset() (mutates)', () => {
     const fake = sinon.fake.returns(null)
-    Renderer.create(<SetValue children={fake} defaultValue={new Set([1])} />)
+    const initial = new Set([1])
+    Renderer.create(<SetValue children={fake} defaultValue={initial} />)
     fake.lastArg.set(new Set([2]))
     fake.lastArg.reset()
-    assert.deepEqual(fake.lastArg.value, new Set([1]))
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Set([1]))
+    assert.notEqual(value, initial)
   })
 
-  it('clear()', () => {
+  it('clear() (mutates)', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<SetValue children={fake} defaultValue={new Set([1])} />)
     fake.lastArg.set(new Set([2]))
+    const previous = fake.lastArg.value
     fake.lastArg.clear()
-    assert.deepEqual(fake.lastArg.value, new Set())
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Set())
+    assert.notEqual(value, previous)
   })
 
   it('add(val)', () => {
@@ -66,18 +61,24 @@ describe('<SetValue>', () => {
     assert.deepEqual(fake.lastArg.value, new Set([2]))
   })
 
-  it('delete(val)', () => {
+  it('delete(val) (mutates)', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<SetValue children={fake} defaultValue={new Set([1, 2])} />)
+    const previous = fake.lastArg.value
     fake.lastArg.delete(1)
-    assert.deepEqual(fake.lastArg.value, new Set([2]))
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Set([2]))
+    assert.notEqual(value, previous)
   })
 
-  it('remove(val) (alias)', () => {
+  it('remove(val) (alias) (mutates)', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<SetValue children={fake} defaultValue={new Set([1, 2])} />)
+    const previous = fake.lastArg.value
     fake.lastArg.remove(1)
-    assert.deepEqual(fake.lastArg.value, new Set([2]))
+    const { value } = fake.lastArg
+    assert.deepEqual(value, new Set([2]))
+    assert.notEqual(value, previous)
   })
 
   it('toggle(val, boolean)', () => {


### PR DESCRIPTION
This allows transforms to define whether they mutate or not, and it clones the value before giving it to them if so. This way new values can always be compared by reference, even for things like arrays, maps and sets.

Fixes #5 
