### PR TITLE
add `disabled` as a render prop

### DIFF
--- a/src/components/any-value.js
+++ b/src/components/any-value.js
@@ -78,11 +78,11 @@ class AnyValue extends React.Component {
 
   render() {
     const { props, transforms, computeds, value } = this
-    const { children, render } = props
+    const { children, render, disabled = false } = props
     const fn = children || render
     if (fn === null) return null
 
-    const renderProps = { value, ...transforms }
+    const renderProps = { value, disabled, ...transforms }
 
     for (const key in computeds) {
       renderProps[key] = computeds[key]()

--- a/test/components/any-value.js
+++ b/test/components/any-value.js
@@ -62,11 +62,18 @@ describe('<AnyValue>', () => {
     assert.equal(fake.lastArg.value, 42)
   })
 
+  it('enabled', () => {
+    const fake = sinon.fake.returns(null)
+    Renderer.create(<AnyValue children={fake} />)
+    assert.equal(fake.lastArg.disabled, false)
+  })
+
   it('disabled', () => {
     const fake = sinon.fake.returns(null)
     Renderer.create(<AnyValue children={fake} disabled />)
     const { callCount } = fake
     fake.lastArg.set(true)
+    assert.equal(fake.lastArg.disabled, true)
     assert.notEqual(fake.lastArg.value, true)
     assert.equal(fake.callCount, callCount)
   })


### PR DESCRIPTION
This adds the `disabled` prop as a render prop so children components can render based on it!

Fixes https://github.com/ianstormtaylor/react-values/issues/18